### PR TITLE
Change build cache source repository for gh hook

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker build \
-       --cache-from egarchive/lega-inbox:stable \
+       --cache-from nbisweden/ega-inbox:m7 \
        --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
        --build-arg SOURCE_COMMIT=$(git rev-parse --short HEAD) \
        --tag $IMAGE_NAME .


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The image source for caching in automated builds now points to `nbisweden` Docker Hub repository.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) NeIC GH account has permissions for pushing to the NBISweden Docker Hub account.
2) Trigger for builds has been created in NBISweden's inbox repository.
3) The image source for caching in automated builds changed.
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
